### PR TITLE
fastboot: stop trying to determine bootloader unlock status from /pro…

### DIFF
--- a/fastboot/device/utility.cpp
+++ b/fastboot/device/utility.cpp
@@ -204,12 +204,7 @@ std::vector<std::string> ListPartitions(FastbootDevice* device) {
 }
 
 bool GetDeviceLockStatus() {
-    std::string cmdline;
-    // Return lock status true if unable to read kernel command line.
-    if (!android::base::ReadFileToString("/proc/cmdline", &cmdline)) {
-        return true;
-    }
-    return cmdline.find("androidboot.verifiedbootstate=orange") == std::string::npos;
+    return android::base::GetProperty("ro.boot.verifiedbootstate", "") != "orange";
 }
 
 bool UpdateAllPartitionMetadata(FastbootDevice* device, const std::string& super_name,


### PR DESCRIPTION
…c/cmdline

* raven (and others i'm sure) still has no read access to /proc/cmdline even
  with an unlocked bootloader. This check was failing and broke writing to
  partitions.

Signed-off-by: Matt Filetto <matt.filetto@gmail.com>