### PR TITLE
Unshare mount namespace in bootchart's thread

### DIFF
--- a/init/bootchart.cpp
+++ b/init/bootchart.cpp
@@ -140,6 +140,20 @@ static void log_processes(FILE* log) {
 static void bootchart_thread_main() {
   LOG(INFO) << "Bootcharting started";
 
+  // Unshare the mount namespace of this thread so that the init process itself can switch
+  // the mount namespace later while this thread is still running.
+  // Otherwise, setns() call invoked as part of `enter_default_mount_ns` fails with EINVAL.
+  //
+  // Note that after unshare()'ing the mount namespace from the main thread, this thread won't
+  // receive mount/unmount events from the other mount namespace unless the events are happening
+  // from under a sharable mount.
+  //
+  // The bootchart thread is safe to unshare the mount namespace because it only reads from /proc
+  // and write to /data which are not private mounts.
+  if (unshare(CLONE_NEWNS) == -1) {
+      PLOG(ERROR) << "Cannot create mount namespace";
+      return;
+  }
   // Open log files.
   auto stat_log = fopen_unique("/data/bootchart/proc_stat.log", "we");
   if (!stat_log) return;


### PR DESCRIPTION
When bootchart is enabled its thread shares the mount namespace context
with the main thread. This prevents the main thread to switch the mount
namespace later with setns().

So, unshare() the mount namespace of the bootchart thread.

Bug: 229983560
Test: rebooted with bootcharting on/off
    enter_default_mount_ns should succeeded.
Change-Id: Idac0d0efcb4f7f7d8a7cbcebf8fa2fa29f104c35
(cherry picked from commit 7f8721b9926c2cac6834ff8e4ffd7b38c3b1b3de)