### PR TITLE
fs_mgr: autodetect filesystem type

### DIFF
--- a/fs_mgr/Android.bp
+++ b/fs_mgr/Android.bp
@@ -103,7 +103,6 @@ cc_defaults {
     whole_static_libs: [
         "liblogwrap",
         "libdm",
-        "libext2_uuid",
         "libfscrypt",
         "libfstab",
     ],
@@ -178,6 +177,10 @@ cc_library_static {
         "fs_mgr_fstab.cpp",
         "fs_mgr_boot_config.cpp",
         "fs_mgr_slotselect.cpp",
+    ],
+    whole_static_libs: [
+        "libext2_blkid",
+        "libext2_uuid",
     ],
     target: {
         darwin: {

--- a/fs_mgr/fs_mgr_fstab.cpp
+++ b/fs_mgr/fs_mgr_fstab.cpp
@@ -34,6 +34,7 @@
 #include <android-base/properties.h>
 #include <android-base/stringprintf.h>
 #include <android-base/strings.h>
+#include <blkid/blkid.h>
 #include <libgsi/libgsi.h>
 
 #include "fs_mgr_priv.h"
@@ -878,6 +879,28 @@ std::vector<FstabEntry*> GetEntriesForMountPoint(Fstab* fstab, const std::string
     }
 
     return entries;
+}
+
+FstabEntry* GetEntryForMountPointTryDetectFs(Fstab* fstab, const std::string& path) {
+    if (fstab == nullptr) {
+        return nullptr;
+    }
+    FstabEntry* found = GetEntryForMountPoint(fstab, path);
+    if (found == nullptr) {
+        return nullptr;
+    }
+
+    if (char* detected_fs_type = blkid_get_tag_value(nullptr, "TYPE", found->blk_device.c_str())) {
+        for (auto& entry : *fstab) {
+            if (entry.mount_point == path && entry.fs_type == detected_fs_type) {
+                found = &entry;
+                break;
+            }
+        }
+        free(detected_fs_type);
+    }
+
+    return found;
 }
 
 std::set<std::string> GetBootDevices() {

--- a/fs_mgr/fs_mgr_roots.cpp
+++ b/fs_mgr/fs_mgr_roots.cpp
@@ -37,7 +37,7 @@ FstabEntry* GetEntryForPath(Fstab* fstab, const std::string& path) {
     if (path.empty()) return nullptr;
     std::string str(path);
     while (true) {
-        auto entry = GetEntryForMountPoint(fstab, str);
+        auto entry = GetEntryForMountPointTryDetectFs(fstab, str);
         if (entry != nullptr) return entry;
         if (str == "/") break;
         auto slash = str.find_last_of('/');

--- a/fs_mgr/include_fstab/fstab/fstab.h
+++ b/fs_mgr/include_fstab/fstab/fstab.h
@@ -105,8 +105,11 @@ bool ReadDefaultFstab(Fstab* fstab);
 bool SkipMountingPartitions(Fstab* fstab, bool verbose = false);
 
 FstabEntry* GetEntryForMountPoint(Fstab* fstab, const std::string& path);
+
 // The Fstab can contain multiple entries for the same mount point with different configurations.
 std::vector<FstabEntry*> GetEntriesForMountPoint(Fstab* fstab, const std::string& path);
+
+FstabEntry* GetEntryForMountPointTryDetectFs(Fstab* fstab, const std::string& path);
 
 // This method builds DSU fstab entries and transfer the fstab.
 //


### PR DESCRIPTION
* Multiple fstab lines (supported in android) cause recovery to fail
  to mount partitions if the fs type is not the same as the first
  fstab entry. So when we attempt to find an fstab entry, check it
  against blkid's determination of what filesystem type it is.

* If blkid fails, or if no entry matches the detected fs type,
  return the first found.

[aleasto: revamped for Q]

Change-Id: I7b720b534185fc7cb3860833aa49f748e02e3f6c