### PR TITLE
Revert "snapuserd: opt out of Global ThinLTO to workaround segfault"

### DIFF
--- a/fs_mgr/libsnapshot/snapuserd/Android.bp
+++ b/fs_mgr/libsnapshot/snapuserd/Android.bp
@@ -130,12 +130,6 @@ cc_defaults {
     // snapuserd, which would lead to deadlock if we had to handle page
     // faults for its code pages.
     static_executable: true,
-
-    // Snapuserd segfaults with ThinLTO
-    // http://b/208565717
-    lto: {
-         never: true,
-    },
 }
 
 cc_binary {


### PR DESCRIPTION
This reverts commit 9d0c06d3e203b8bdb6710332dc59f51948788e01.

The failure is fixed by https://r.android.com/2725997. Workaround no longer needed.

Test: manual
Bug: 208565717
Bug: 295944813
Change-Id: I83638938bf52a4b2b1e72743f892c579622ba9e6