### PR TITLE
debuggerd: use jemalloc by default and allow opt-in to scudo (4/4)

### DIFF
--- a/debuggerd/Android.bp
+++ b/debuggerd/Android.bp
@@ -257,7 +257,7 @@ cc_library_static {
             cflags: ["-DROOT_POSSIBLE"],
         },
 
-        malloc_not_svelte: {
+        malloc_use_scudo: {
             cflags: ["-DUSE_SCUDO"],
             whole_static_libs: ["libscudo"],
             srcs: ["libdebuggerd/scudo.cpp"],


### PR DESCRIPTION
Since we have switched to jemalloc (bionic).

Change-Id: Ie89f9a7be4e965abf346402084a2a2d032771d3e