### PR TITLE
Revert "boost uclamp_min for loading modules in parallel"

### DIFF
--- a/libmodprobe/libmodprobe.cpp
+++ b/libmodprobe/libmodprobe.cpp
@@ -19,8 +19,6 @@
 #include <fnmatch.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
-#include <sched.h>
-#include <unistd.h>
 
 #include <algorithm>
 #include <map>
@@ -34,19 +32,6 @@
 #include <android-base/logging.h>
 #include <android-base/strings.h>
 #include <android-base/unique_fd.h>
-
-struct sched_attr {
-    unsigned int size;
-    unsigned int sched_policy;
-    unsigned long long sched_flags;
-    int sched_nice;
-    unsigned int sched_priority;
-    unsigned long long sched_runtime;
-    unsigned long long sched_deadline;
-    unsigned long long sched_period;
-    unsigned int sched_util_min;
-    unsigned int sched_util_max;
-};
 
 std::string Modprobe::MakeCanonical(const std::string& module_path) {
     auto start = module_path.find_last_of('/');
@@ -508,17 +493,6 @@ bool Modprobe::LoadModulesParallel(int num_threads) {
 
         // Load independent modules in parallel
         auto thread_function = [&] {
-#if defined(__NR_sched_setattr) && defined(SCHED_FLAG_RESET_ON_FORK)
-            int pid = getpid();
-            sched_attr attr = {};
-            attr.size = sizeof(attr);
-            attr.sched_flags =
-                (SCHED_FLAG_RESET_ON_FORK | SCHED_FLAG_KEEP_ALL | SCHED_FLAG_UTIL_CLAMP_MIN);
-            attr.sched_util_min = 1024;
-
-            syscall(__NR_sched_setattr, pid, attr, 0);
-#endif
-
             std::unique_lock lk(vector_lock);
             while (!mods_path_to_load.empty()) {
                 auto ret_load = true;


### PR DESCRIPTION
This reverts commit 045521dd2cd6139517214a533ee9826399f2f130.

Was observing CPU freq spikes on pixel devices recently, tracked it down to this exact change. If i revert this commit, no more spikes, apply it, spikes return. 