### PR TITLE
snapuserd: mark as recovery_available

### DIFF
--- a/fs_mgr/libsnapshot/snapuserd/Android.bp
+++ b/fs_mgr/libsnapshot/snapuserd/Android.bp
@@ -139,6 +139,7 @@ cc_binary {
         "snapuserd.rc",
     ],
     ramdisk_available: false,
+    recovery_available: true,
     vendor_ramdisk_available: true,
 }
 


### PR DESCRIPTION
When i tried to build crDroid 10 for my phone i got this error:

```
FAILED:
build/make/core/main.mk:1342: warning:  device/daria/zahedan/lineage_zahedan.mk includes non-existent modules in PRODUCT_PACKAGES
Offending entries:
snapuserd.recovery
```
with this change my error got fixed