### PR TITLE
Revert "Start statsd before starting zygote"

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -1029,7 +1029,6 @@ on zygote-start && property:ro.crypto.state=unencrypted
     wait_for_prop odsign.verification.done 1
     # A/B update verifier that marks a successful boot.
     exec_start update_verifier_nonencrypted
-    start statsd
     start netd
     start zygote
     start zygote_secondary
@@ -1038,7 +1037,6 @@ on zygote-start && property:ro.crypto.state=unsupported
     wait_for_prop odsign.verification.done 1
     # A/B update verifier that marks a successful boot.
     exec_start update_verifier_nonencrypted
-    start statsd
     start netd
     start zygote
     start zygote_secondary
@@ -1047,7 +1045,6 @@ on zygote-start && property:ro.crypto.state=encrypted && property:ro.crypto.type
     wait_for_prop odsign.verification.done 1
     # A/B update verifier that marks a successful boot.
     exec_start update_verifier_nonencrypted
-    start statsd
     start netd
     start zygote
     start zygote_secondary


### PR DESCRIPTION
This reverts commit acb55fe4d950cbe379d2c10388a9c680d70902df.

No, actually, we really DO want it off.

A little bit of error spam on boot is far better than crippling CPU utilization after 3 days of uptime.

For more info, see Change-Id: Idf6fdb0eff987169bd5f370dd72315e831a669e6