### PR TITLE
T_asb_2024-06

### DIFF
--- a/fs_mgr/liblp/builder.cpp
+++ b/fs_mgr/liblp/builder.cpp
@@ -1043,8 +1043,8 @@ bool MetadataBuilder::UpdateBlockDeviceInfo(size_t index, const BlockDeviceInfo&
     CHECK(index < block_devices_.size());
 
     LpMetadataBlockDevice& block_device = block_devices_[index];
-    if (device_info.size != block_device.size) {
-        LERROR << "Device size does not match (got " << device_info.size << ", expected "
+    if (device_info.size < block_device.size) {
+        LERROR << "Device size does not fit (got " << device_info.size << ", expected "
                << block_device.size << ")";
         return false;
     }

--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -1029,7 +1029,6 @@ on zygote-start && property:ro.crypto.state=unencrypted
     wait_for_prop odsign.verification.done 1
     # A/B update verifier that marks a successful boot.
     exec_start update_verifier_nonencrypted
-    start statsd
     start netd
     start zygote
     start zygote_secondary
@@ -1038,7 +1037,6 @@ on zygote-start && property:ro.crypto.state=unsupported
     wait_for_prop odsign.verification.done 1
     # A/B update verifier that marks a successful boot.
     exec_start update_verifier_nonencrypted
-    start statsd
     start netd
     start zygote
     start zygote_secondary
@@ -1047,7 +1045,6 @@ on zygote-start && property:ro.crypto.state=encrypted && property:ro.crypto.type
     wait_for_prop odsign.verification.done 1
     # A/B update verifier that marks a successful boot.
     exec_start update_verifier_nonencrypted
-    start statsd
     start netd
     start zygote
     start zygote_secondary


### PR DESCRIPTION
Technically this isn't part of the ASB, but does includes changes from 0xCAFEBABE at LineageOS necessary to correctly include super_empty.img as part of the standard build targets for devices with retrofit dynamic partitions.

Also reapplies kdrag0n's commit to disable statsd service on boot in this repo as well, to help kill the horrendous battery drain after ~85h of uptime.