### PR TITLE
init.rc: Improve F2FS checkpoint thread IO priority

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -1192,6 +1192,9 @@ on boot
     write /dev/sys/fs/by-name/userdata/iostat_period_ms 1000
     write /dev/sys/fs/by-name/userdata/iostat_enable 1
 
+    # set highest IO priority for F2FS checkpoint thread
+    write /dev/sys/fs/by-name/userdata/ckpt_thread_ioprio "rt,3"
+
     # set readahead multiplier for POSIX_FADV_SEQUENTIAL files
     write /dev/sys/fs/by-name/userdata/seq_file_ra_mul 128
 


### PR DESCRIPTION
* Based on f2fs-for-6.15-rc1 (8a2d9f00d502e6ef68c6d52f0863856040dd) The checkpoint is the top priority thread which can stop all the filesystem operations. Let's make it RT priority.
* For older machines (if using stock/prebuilt kernels etc), change ckpt_thread_ioprio on the system side if it exists.

Test: My device userdata thread name is f2fs_ckpt-252:4 PID is 785
      Use ("ionice -p 785") to echo ("Realtime: prio 3"), Mount on
      F2FS partition separately, and echo ("Best-effort: prio 3").

Change-Id: Ia9412d6da3bf57236e43a5183c8df4a31ef7c54e